### PR TITLE
confirm/deny request functionality added

### DIFF
--- a/app/src/main/java/com/toolsharemobile/myapplication/activity/ViewBorrowedToolActivity.java
+++ b/app/src/main/java/com/toolsharemobile/myapplication/activity/ViewBorrowedToolActivity.java
@@ -13,7 +13,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.amplifyframework.api.graphql.model.ModelMutation;
 import com.amplifyframework.api.graphql.model.ModelQuery;
 import com.amplifyframework.auth.AuthUser;
-import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.datastore.generated.model.Tool;
 import com.google.android.material.snackbar.Snackbar;
@@ -38,7 +37,7 @@ public class ViewBorrowedToolActivity extends AppCompatActivity {
         toolCompletableFuture = new CompletableFuture<>();
 
         setUpUIelements();
-        setUpBorrowButton();
+        setUpReturnRequestButton();
     }
 
 
@@ -103,7 +102,7 @@ public class ViewBorrowedToolActivity extends AppCompatActivity {
 
 
 
-    private void setUpBorrowButton() {
+    private void setUpReturnRequestButton() {
         Button borrowToolButton = findViewById(R.id.returnToolSubmitButton);
 
         borrowToolButton.setOnClickListener(new View.OnClickListener() {
@@ -123,22 +122,22 @@ public class ViewBorrowedToolActivity extends AppCompatActivity {
                         .lon(toolToEdit.getLon())
                         .id(toolToEdit.getId())
                         .openBorrowRequest(false)
-                        .openReturnRequest(false)
-                        .isAvailable(true)
-                        .borrowByUser(null)
+                        .openReturnRequest(true)
+                        .isAvailable(false)
+                        .borrowByUser(toolToEdit.getBorrowByUser())
                         .build();
 
                 Amplify.API.mutate(
                         ModelMutation.update(toolToSave),
                         successResponse -> {
-                            Log.i(TAG, "Returned a tool successfully!");
+                            Log.i(TAG, "Created a tool return request successfully!");
 
                             Intent goToHomeActivity = new Intent(ViewBorrowedToolActivity.this, ProfileActivity.class);
                             startActivity(goToHomeActivity);
                         },
                         failureResponse -> {
-                            Log.i(TAG, "Failed to return tool with this response: "+ failureResponse);
-                            Snackbar.make(findViewById(R.id.viewToolActivity), "Tool not returned!", Snackbar.LENGTH_SHORT).show();
+                            Log.i(TAG, "Failed to make a tool return request: "+ failureResponse);
+                            Snackbar.make(findViewById(R.id.viewToolActivity), "tool return request failed!", Snackbar.LENGTH_SHORT).show();
                         }
                 );
 

--- a/app/src/main/java/com/toolsharemobile/myapplication/activity/ViewLendedToolActivity.java
+++ b/app/src/main/java/com/toolsharemobile/myapplication/activity/ViewLendedToolActivity.java
@@ -41,7 +41,10 @@ public class ViewLendedToolActivity extends AppCompatActivity {
 
         setUpUIelements();
         setUpRemoveToolListingButton();
-
+        setUpConfirmBorrowButton();
+        setUpDenyBorrowButton();
+        setUpConfirmReturnButton();
+        setUpContestReturnButton();
     }
 
 
@@ -137,5 +140,185 @@ public class ViewLendedToolActivity extends AppCompatActivity {
 
     public void setUpConfirmBorrowButton(){
 
+        Button confirmBorrowRequest = findViewById(R.id.confirmButton);
+        confirmBorrowRequest.setVisibility(View.INVISIBLE);
+        if (toolToEdit.getOpenBorrowRequest()) {
+            confirmBorrowRequest.setVisibility(View.VISIBLE);
+        }
+        confirmBorrowRequest.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+
+                if (Amplify.Auth.getCurrentUser() != null) {
+                    authUser = Amplify.Auth.getCurrentUser();
+                    username = authUser.getUsername();
+                } else {
+                    username = "Jimbo";
+                }
+
+                Tool toolToSave = Tool.builder()
+                        .toolType(toolToEdit.getToolType())
+                        .listedByUser(toolToEdit.getListedByUser())
+                        .lat(toolToEdit.getLat())
+                        .lon(toolToEdit.getLon())
+                        .id(toolToEdit.getId())
+                        .openBorrowRequest(false)
+                        .openReturnRequest(false)
+                        .isAvailable(false)
+                        .borrowByUser(toolToEdit.getBorrowByUser())
+                        .build();
+
+                Amplify.API.mutate(
+                        ModelMutation.update(toolToSave),
+                        successResponse -> {
+                            Log.i(TAG, "Confirmed Tool borrow request successfully!");
+
+                            Intent goToHomeActivity = new Intent(ViewLendedToolActivity.this, ProfileActivity.class);
+                            startActivity(goToHomeActivity);
+                        },
+                        failureResponse -> {
+                            Log.i(TAG, "Failed to confirm tool borrow request with this response: " + failureResponse);
+                            Snackbar.make(findViewById(R.id.viewToolActivity), "Failed to confirm tool borrow request!", Snackbar.LENGTH_SHORT).show();
+                        }
+                );
+            }
+        });
     }
+
+    public void setUpDenyBorrowButton() {
+        Button denyBorrowButton = findViewById(R.id.denyButton);
+        denyBorrowButton.setVisibility(View.INVISIBLE);
+        if (toolToEdit.getOpenBorrowRequest()) {
+            denyBorrowButton.setVisibility(View.VISIBLE);
+        }
+        denyBorrowButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (Amplify.Auth.getCurrentUser() != null) {
+                    authUser = Amplify.Auth.getCurrentUser();
+                    username = authUser.getUsername();
+                } else {
+                    username = "Jimbo";
+                }
+
+                Tool toolToSave = Tool.builder()
+                        .toolType(toolToEdit.getToolType())
+                        .listedByUser(toolToEdit.getListedByUser())
+                        .lat(toolToEdit.getLat())
+                        .lon(toolToEdit.getLon())
+                        .id(toolToEdit.getId())
+                        .openBorrowRequest(false)
+                        .openReturnRequest(false)
+                        .isAvailable(true)
+                        .borrowByUser(null)
+                        .build();
+
+                Amplify.API.mutate(
+                        ModelMutation.update(toolToSave),
+                        successResponse -> {
+                            Log.i(TAG, "Denied Tool borrow request successfully!");
+
+                            Intent goToHomeActivity = new Intent(ViewLendedToolActivity.this, ProfileActivity.class);
+                            startActivity(goToHomeActivity);
+                        },
+                        failureResponse -> {
+                            Log.i(TAG, "Failed to deny tool borrow request with this response: " + failureResponse);
+                            Snackbar.make(findViewById(R.id.viewToolActivity), "Failed to deny tool borrow request!", Snackbar.LENGTH_SHORT).show();
+                        }
+                );
+            }
+        });
+    }
+
+    public void setUpConfirmReturnButton() {
+        Button confirmReturnButton = findViewById(R.id.returnConfirmButton);
+        confirmReturnButton.setVisibility(View.INVISIBLE);
+        if (toolToEdit.getOpenReturnRequest()) {
+            confirmReturnButton.setVisibility(View.VISIBLE);
+        }
+        confirmReturnButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (Amplify.Auth.getCurrentUser() != null) {
+                    authUser = Amplify.Auth.getCurrentUser();
+                    username = authUser.getUsername();
+                } else {
+                    username = "Jimbo";
+                }
+
+                Tool toolToSave = Tool.builder()
+                        .toolType(toolToEdit.getToolType())
+                        .listedByUser(toolToEdit.getListedByUser())
+                        .lat(toolToEdit.getLat())
+                        .lon(toolToEdit.getLon())
+                        .id(toolToEdit.getId())
+                        .openBorrowRequest(false)
+                        .openReturnRequest(false)
+                        .isAvailable(true)
+                        .borrowByUser(null)
+                        .build();
+
+                Amplify.API.mutate(
+                        ModelMutation.update(toolToSave),
+                        successResponse -> {
+                            Log.i(TAG, "Confirmed Tool return request successfully!");
+
+                            Intent goToHomeActivity = new Intent(ViewLendedToolActivity.this, ProfileActivity.class);
+                            startActivity(goToHomeActivity);
+                        },
+                        failureResponse -> {
+                            Log.i(TAG, "Failed to confirm tool return request with this response: " + failureResponse);
+                            Snackbar.make(findViewById(R.id.viewToolActivity), "Failed to confirm tool return request!", Snackbar.LENGTH_SHORT).show();
+                        }
+                );
+            }
+        });
+    }
+
+    public void setUpContestReturnButton() {
+        Button contestReturnButton = findViewById(R.id.returnButtonDeny);
+        contestReturnButton.setVisibility(View.INVISIBLE);
+        if (toolToEdit.getOpenReturnRequest()) {
+            contestReturnButton.setVisibility(View.VISIBLE);
+        }
+        contestReturnButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (Amplify.Auth.getCurrentUser() != null) {
+                    authUser = Amplify.Auth.getCurrentUser();
+                    username = authUser.getUsername();
+                } else {
+                    username = "Jimbo";
+                }
+
+                Tool toolToSave = Tool.builder()
+                        .toolType(toolToEdit.getToolType())
+                        .listedByUser(toolToEdit.getListedByUser())
+                        .lat(toolToEdit.getLat())
+                        .lon(toolToEdit.getLon())
+                        .id(toolToEdit.getId())
+                        .openBorrowRequest(false)
+                        .openReturnRequest(false)
+                        .isAvailable(false)
+                        .borrowByUser(toolToEdit.getBorrowByUser())
+                        .build();
+
+                Amplify.API.mutate(
+                        ModelMutation.update(toolToSave),
+                        successResponse -> {
+                            Log.i(TAG, "Contested Tool return request successfully!");
+
+                            Intent goToHomeActivity = new Intent(ViewLendedToolActivity.this, ProfileActivity.class);
+                            startActivity(goToHomeActivity);
+                        },
+                        failureResponse -> {
+                            Log.i(TAG, "Failed to Contest tool return request with this response: " + failureResponse);
+                            Snackbar.make(findViewById(R.id.viewToolActivity), "Failed to Contest tool return request!", Snackbar.LENGTH_SHORT).show();
+                        }
+                );
+            }
+        });
+    }
+
+
 }

--- a/app/src/main/res/layout/activity_view_lended_tool.xml
+++ b/app/src/main/res/layout/activity_view_lended_tool.xml
@@ -78,12 +78,12 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        android:id="@+id/returnButton"
+        android:id="@+id/returnButtonDeny"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
         android:layout_marginBottom="24dp"
-        android:text="Return"
+        android:text="Contest Return"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 


### PR DESCRIPTION
- Users can request to borrow tools from others
- Owners of tools can confirm or deny requests to borrow their tools
- Users can request to return tools to owners
- Owners can confirm or contest returns from loaners